### PR TITLE
Update README with link to PHPStan website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [PHP-Enum](https://github.com/marc-mabe/php-enum) enumerations with native PHP.
 
-[PHPStan](https://github.com/phpstan/phpstan) is a static code analysis tool.
+[PHPStan](https://phpstan.org/) is a static code analysis tool.
 
 > PHPStan focuses on finding errors in your code without actually running it.
 > It catches whole classes of bugs even before you write tests for the code.


### PR DESCRIPTION
I created a new PHPStan website with full-fledged documentation, so I'd like all links to reflect this :) Thanks.