### PR TITLE
MabeEnumPhpstan\EnumDynamicReturnTypeExtension::getTypeFromStaticMethodCall() cant handle static calls on variables

### DIFF
--- a/src/EnumDynamicReturnTypeExtension.php
+++ b/src/EnumDynamicReturnTypeExtension.php
@@ -3,6 +3,7 @@
 namespace MabeEnumPHPStan;
 
 use MabeEnum\Enum;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
@@ -81,6 +82,9 @@ class EnumDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
         StaticCall $staticCall,
         Scope $scope
     ): Type {
+        if ($staticCall->class instanceof Expr) {
+            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        }
         $callClass = $staticCall->class->toString();
 
         // Can't detect possible types on static::*()

--- a/tests/integration/data/EnumGetValuesReturnType-3.json
+++ b/tests/integration/data/EnumGetValuesReturnType-3.json
@@ -1,22 +1,22 @@
 [
     {
         "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\Example::staticMethodFail() should return array<int, null> but returns array<int, float|int|string>.",
-        "line": 24,
+        "line": 33,
         "ignorable": true
     },
     {
         "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\Example::objectMethodFail() should return array<int, null> but returns array<int, float|int|string>.",
-        "line": 36,
+        "line": 45,
         "ignorable": true
     },
     {
         "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyEnum::selfGetValuesFail() should return array<int, null> but returns array<int, int|string>.",
-        "line": 54,
+        "line": 63,
         "ignorable": true
     },
     {
         "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyInheritedEnum::inheritSelfGetValuesFail() should return array<int, null> but returns array<int, float|int|string>.",
-        "line": 77,
+        "line": 86,
         "ignorable": true
     }
 ]

--- a/tests/integration/data/EnumGetValuesReturnType-7.json
+++ b/tests/integration/data/EnumGetValuesReturnType-7.json
@@ -1,12 +1,17 @@
 [
     {
-        "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyEnum::staticGetValuesFail() should return array<int, null> but returns array<int, array|bool|float|int|string|null>.",
-        "line": 60,
+        "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\Example::getDynamicValues() should return array<int, float|int|string> but returns array<int, array<int|string, mixed>|bool|float|int|string|null>.",
+        "line": 15,
         "ignorable": true
     },
     {
-        "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyInheritedEnum::inheritStaticGetValuesFail() should return array<int, null> but returns array<int, array|bool|float|int|string|null>.",
-        "line": 83,
+        "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyEnum::staticGetValuesFail() should return array<int, null> but returns array<int, array<int|string, mixed>|bool|float|int|string|null>.",
+        "line": 69,
+        "ignorable": true
+    },
+    {
+        "message": "Method MabeEnum\\PHPStan\\tests\\integration\\data\\EnumGetValuesReturnType\\MyInheritedEnum::inheritStaticGetValuesFail() should return array<int, null> but returns array<int, array<int|string, mixed>|bool|float|int|string|null>.",
+        "line": 92,
         "ignorable": true
     }
 ]

--- a/tests/integration/data/EnumGetValuesReturnType.php
+++ b/tests/integration/data/EnumGetValuesReturnType.php
@@ -6,6 +6,15 @@ use MabeEnum\Enum;
 
 class Example
 {
+    /** @var class-string<Enum> */
+    protected $enumClass = Enum::class;
+
+    /** @return array<int, float|int|string> */
+    public function getDynamicValues(): array
+    {
+        return $this->enumClass::getValues();
+    }
+
     /** @return array<int, null> */
     public static function baseMethodValid(): array
     {


### PR DESCRIPTION
## Why this PR

Given following code:
```php
class EnumType {
    /** @var class-string<\MabeEnum\Enum> */
    protected string $enumClass = \MabeEnum\Enum::class;

    public function convertToPHPValue($value) {
        if (empty($value)) {
            return null;
        }

        if (!$this->enumClass::hasValue($value)) {
            throw new InvalidArgumentException(
                sprintf(
                    'The value "%s" is not valid for the enum "%s". Expected one of ["%s"]',
                    $value,
                    $this->enumClass,
                    implode('", "', $this->enumClass::getValues())
                )
            );
        }

        return $this->enumClass::byValue($value);
    }
}
```

will crash as `MabeEnumPhpstan\EnumDynamicReturnTypeExtension::getTypeFromStaticMethodCall()` tries to call `$staticCall->class->toString();`. This happens cause `$staticCall->class` can be both `PhpParser\Node\Name` (no problem) but also `PhpParser\Node\Expr` which doesn't have the `toString()` method.

## What does this PR do
While not feeling like the perfect solution this PR makes sure that we use the default `Enum::getValues()` if we can't statically determine which Enum will be used